### PR TITLE
Adjusted styling so it doesn't move up on Linux

### DIFF
--- a/src/components/NewTodoItem/styles.module.css
+++ b/src/components/NewTodoItem/styles.module.css
@@ -16,6 +16,7 @@
   background-color: rgba(0, 0, 0, 0);
   border: none;
   border-bottom: 1px solid var(--primary-color-light);
+  box-sizing: border-box;
   color: var(--foreground-color);
   font-family: var(--font-family);
   font-size: 20px;
@@ -25,8 +26,7 @@
 
 .textInput:hover {
   background-color: rgba(0, 0, 0, 0);
-  border-bottom: 2px solid var(--primary-color);
-  margin-top: -1px;
+  border-bottom: 1px solid var(--primary-color);
   transition: var(--animation-duration) border-bottom-color
     var(--animation-curve);
 }


### PR DESCRIPTION
### Changes
Unfortunately, the styling works different under Linux, where making the border bigger doesn't move the input up like it does on windows, so to have both have the same behavior, the border is make the same size on hover